### PR TITLE
Default author on add

### DIFF
--- a/add_photos.php
+++ b/add_photos.php
@@ -462,6 +462,7 @@ $template->assign(
     'switch_url' => PHOTOS_ADD_BASE_URL.'&amp;upload_mode='.$upload_switch,
     'upload_id' => md5(rand()),
     'session_id' => session_id(),
+    'user_name' => $user['username'],
     'another_upload_link' => PHOTOS_ADD_BASE_URL.'&amp;upload_mode='.$upload_mode,
     )
   );

--- a/add_photos.php.save
+++ b/add_photos.php.save
@@ -161,7 +161,7 @@ SELECT
   
   // reinitialize the informations to display on the result page
   $page['infos'] = array();
-echo $_POST;
+
   if (isset($_POST['set_photo_properties']) || isset($_POST['author']))
   {
     $data = array();

--- a/add_photos.tpl
+++ b/add_photos.tpl
@@ -576,7 +576,7 @@ p#uploadModeInfos {text-align:left;margin-top:1em;font-size:90%;color:#999;}
 
       <p>
         {'Author'|@translate}<br>
-        <input type="text" class="large" name="author" value="{$user_name}">
+        <input type="text" class="large" name="author" {if $user_name neq ''} readonly {/if} value="{$user_name}">
       </p>
 
       <p>

--- a/add_photos.tpl
+++ b/add_photos.tpl
@@ -576,7 +576,7 @@ p#uploadModeInfos {text-align:left;margin-top:1em;font-size:90%;color:#999;}
 
       <p>
         {'Author'|@translate}<br>
-        <input type="text" class="large" name="author" value="">
+        <input type="text" class="large" name="author" value="{$user_name}">
       </p>
 
       <p>

--- a/admin_config.php
+++ b/admin_config.php
@@ -49,6 +49,7 @@ if (!empty($_POST))
   $conf['community'] = array(
     'user_albums' => !empty($_POST['user_albums']),
     'user_albums_parent' => $_POST['user_albums_parent'],
+    'hardcoded_author' => $_POST['hardcoded_author'],
     );
 
   conf_update_param('community', serialize($conf['community']));
@@ -67,6 +68,7 @@ $template->set_filename('plugin_admin_content', dirname(__FILE__).'/admin_config
 // +-----------------------------------------------------------------------+
 
 $template->assign('user_albums', $conf['community']['user_albums']);
+$template->assign('hardcoded_author', $conf['community']['hardcoded_author']);
 
 if (isset($conf['community']['user_albums_parent']))
 {

--- a/admin_config.tpl
+++ b/admin_config.tpl
@@ -38,6 +38,8 @@ jQuery(document).ready(function() {
     </select>
   </p>
 
+  <p><label><input type="checkbox" name="hardcoded_author"{if $hardcoded_author} checked="checked"{/if}> <strong>{'Hardcoded Author'|@translate}</strong> : <em>{'The user name will be used as author, and user would not be able to change it.'|@translate}</em></label></p>
+
 	<p class="formButtons">
 		<input type="submit" name="submit" value="{'Save Settings'|@translate}">
 	</p>

--- a/maintain.class.php
+++ b/maintain.class.php
@@ -93,6 +93,7 @@ CREATE TABLE IF NOT EXISTS '.$prefixeTable.'community_pendings (
     {
       $community_default_config = array(
         'user_albums' => false,
+        'hardcoded_author' => false,
         );
       
       conf_update_param('community', $community_default_config, true);


### PR DESCRIPTION
I've added a feature to the config section, allowing the admin to set the author as "hardcoded" - meaning it is automatically set as the user's name and cannot be changed by user when image is uploaded.