### PR TITLE
Add backticks to SQL query for compatibility with MariaDB 10.2

### DIFF
--- a/include/functions_community.inc.php
+++ b/include/functions_community.inc.php
@@ -69,14 +69,14 @@ SELECT
 
   $query = '
 SELECT
-    id,
-    type,
-    category_id,
-    user_album,
-    recursive,
-    create_subcategories,
-    nb_photos,
-    storage
+    `id`,
+    `type`,
+    `category_id`,
+    `user_album`,
+    `recursive`,
+    `create_subcategories`,
+    `nb_photos`,
+    `storage`
   FROM '.COMMUNITY_PERMISSIONS_TABLE.'
   WHERE (type = \'any_visitor\')';
 


### PR DESCRIPTION
"recursive" is now a reserved keyword in MariaDB 10.2 and this query errors out unless backticks are used.