### PR TITLE
Replace deprecated function 'create_function'

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -63,7 +63,7 @@ $tabs = array(
   );
 
 $tab_codes = array_map(
-  create_function('$a', 'return $a["code"];'),
+  function ($a) { return $a["code"]; },
   $tabs
   );
 

--- a/include/functions_community.inc.php
+++ b/include/functions_community.inc.php
@@ -401,7 +401,7 @@ if (!function_exists('safe_version_compare'))
 {
   function safe_version_compare($a, $b, $cmp=null)
   {
-    $replace_chars = create_function('$m', 'return ord(strtolower($m[1]));');
+    $replace_chars = function ($m) { return ord(strtolower($m[1])); };
     $a = preg_replace('#([0-9]+)([a-z]+)#i', '$1.$2', $a);
     $b = preg_replace('#([0-9]+)([a-z]+)#i', '$1.$2', $b);
     $a = preg_replace_callback('#\b([a-z]{1})\b#i', $replace_chars, $a);


### PR DESCRIPTION
This should fix #45.
For compatibility with PHP 7.2 I replaced the deprecated function 'create_function' with anonymous functions. Now PHP >= 5.3.0 is required.