### PR TITLE
de_DE (German) translation fix + added margin-top to div#linktoCreate Box

### DIFF
--- a/add_photos.tpl
+++ b/add_photos.tpl
@@ -201,7 +201,7 @@ var limit_storage = {$limit_storage};
 		
 		filters : {
 			// Maximum file size
-			max_file_size : '1000mb',
+			max_file_size : '{/literal}{$upload_max_filesize}{literal}',
 			// Specify what files to browse for
 			mime_types: [
 				{title : "Image files", extensions : "{/literal}{$file_exts}{literal}"}

--- a/add_photos.tpl
+++ b/add_photos.tpl
@@ -420,6 +420,10 @@ p#uploadModeInfos {text-align:left;margin-top:1em;font-size:90%;color:#999;}
 #uploadForm .plupload_scroll .plupload_filelist {height:250px;}
 #uploadForm li.plupload_droptext {line-height:230px;font-size:2em;}
 
+#uploadForm fieldset#selectAlbum div#linkToCreate {
+  margin-top: 1rem;
+}
+
 #uploadBoxes .file {margin-bottom:5px;text-align:left;}
 #uploadBoxes {margin-top:20px;}
 #addUploadBox {margin-bottom:2em;}

--- a/add_photos.tpl
+++ b/add_photos.tpl
@@ -420,7 +420,7 @@ p#uploadModeInfos {text-align:left;margin-top:1em;font-size:90%;color:#999;}
 #uploadForm .plupload_scroll .plupload_filelist {height:250px;}
 #uploadForm li.plupload_droptext {line-height:230px;font-size:2em;}
 
-#uploadForm fieldset#selectAlbum div#linkToCreate {
+form#uploadForm fieldset.selectAlbum div#linkToCreate {
   margin-top: 1rem;
 }
 

--- a/language/de_DE/plugin.lang.php
+++ b/language/de_DE/plugin.lang.php
@@ -61,7 +61,7 @@ $lang['Edit a permission'] = 'Eine Zugriffsberechtigung ändern';
 $lang['Your photos are waiting for validation, administrators have been notified'] = 'Ihre Fotos müssen zuerst freigeschaltet werden, die Administratoren wurden benachrichtigt.';
 
 
-$lang['Set Photo Properties'] = 'Bildeigenschaften anpassen';
+$lang['Set Photo Properties'] = 'Fotoeigenschaften anpassen';
 $lang['%s out of %s'] = '%s von %s';
 $lang['Available %s.'] = 'Verfügbar %s.';
 $lang['Available quota %s.'] = 'Verfügbarer Speicherplatz %s.';
@@ -82,3 +82,14 @@ $lang['User albums'] = 'Benutzeralben';
 $lang['Where should Piwigo create user albums?'] = 'Wo soll Piwigo Benutzeralben anlegen?';
 $lang['Album of user'] = 'Album des Benutzers';
 $lang['a user can own only one album'] = 'ein Benutzer kann nur Besitzer eines Albums sein';
+
+$lang['Edit photos'] = 'Fotos bearbeiten';
+$lang['Edit Photos'] = 'Fotos bearbeiten';
+$lang['Edit your photos'] = 'Eigene Fotos bearbeiten';
+$lang['Photos posted by %s'] = 'Fotos veröffentlicht von %s';
+$lang['Photos posted by %s in album %s'] = 'Fotos veröffentlicht von %s im Album %s';
+$lang['Select at least one tag'] = 'Mindestens ein Tag muss ausgewählt sein';
+$lang['Select at least one photo'] = 'Mindestens ein Foto muss ausgewählt sein';
+$lang['No photo can be deleted'] = 'Es kann kein Foto gelöscht werden';
+$lang['You need to confirm deletion'] = 'Der Löschvorgang muss bestätigt werden';
+$lang['No photo selected, no action possible.'] = 'Kein Foto ausgewählt, keine Aktion möglich.';


### PR DESCRIPTION
In German "Photo" can be translated to "Foto" oder "Bild".
Translations file had both variants. Should use one convention.
=> Foto is mostly used

+Added missing translations
+Translate convention Photo => Foto

+The Button to add an album overlays the select box (As seen in the attached photo). So i added some margin-top to the div#linktoCreate to fix this

<img width="281" alt="Bildschirmfoto 2022-07-22 um 20 22 22" src="https://user-images.githubusercontent.com/24784171/180500633-9dee9d3d-2bb8-4f9c-b3b6-3cbff3c5e7bd.png">