### PR TITLE
fix #75 by escaping name of `GROUPS_TABLE` in sql queries

### DIFF
--- a/admin_permissions.php
+++ b/admin_permissions.php
@@ -308,7 +308,7 @@ $query = '
 SELECT
     id,
     name
-  FROM '.GROUPS_TABLE.'
+  FROM `'.GROUPS_TABLE.'`
 ;';
 $result = pwg_query($query);
 while ($row = pwg_db_fetch_assoc($result))
@@ -404,7 +404,7 @@ if (!empty($group_ids))
 SELECT
     id,
     name
-  FROM '.GROUPS_TABLE.'
+  FROM `'.GROUPS_TABLE.'`
   WHERE id IN ('.implode(',', $group_ids).')
 ;';
   $result = pwg_query($query);


### PR DESCRIPTION
... because "groups" is a reserved keyword in MySQL 8.

A similar fix was implemented back in 2019 in the main Piwigo repo: https://github.com/Piwigo/Piwigo/commit/c1eecab36415bcba022aa088463ed138fc38b92b